### PR TITLE
Add a --last flag to fetch latest slide info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6 (unreleased)
+
+- Add a --last flag to fetch latest slide info. !12
+- Add support for listing available applications. !10
+
 ## 0.5 (2017-01-31)
 
 - Image upload and info are supported through the ecli slide command

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -25,9 +25,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var cfgInfoLast bool
+
 func slideInfo(args []string) (map[string]interface{}, error) {
 	if len(args) == 0 {
-		return nil, fmt.Errorf("Please provide a slide ID, either as int or hex string.")
+		return nil, fmt.Errorf("Please provide a slide ID (integer)")
 	}
 	id, err := strconv.ParseUint(args[0], 10, 64)
 	if err != nil {
@@ -46,6 +48,31 @@ var infoCmd = &cobra.Command{
 	Aliases: []string{"i"},
 	Short:   "Get slide information",
 	Run: func(cmd *cobra.Command, args []string) {
+		if cfgInfoLast {
+			res, err := api.Search(".") // any
+			if err != nil {
+				log.Fatal(err)
+			}
+			for key, reply := range res {
+				if key != "items" {
+					continue
+				}
+				slides, ok := reply.(map[string]interface{})["slides"]
+				if ok {
+					lslides := slides.([]interface{})
+					if len(lslides) > 0 {
+						s := lslides[len(lslides)-1]
+						slideId := s.(map[string]interface{})["slideId"].(float64)
+						// Rewrite args for later call to slideInfo()
+						args = []string{fmt.Sprintf("%.0f", slideId)}
+						break
+					} else {
+						log.Fatal("No slide uploaded so far, so no info to display.")
+					}
+				}
+			}
+		}
+
 		res, err := slideInfo(args)
 		if err != nil {
 			log.Fatal(err)
@@ -70,4 +97,5 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// infoCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	infoCmd.Flags().BoolVarP(&cfgInfoLast, "last", "l", false, "Show info about last uploaded image")
 }


### PR DESCRIPTION
Use `ecli slide info --last` to get slide info about the latest
uploaded slide. More user friendly than running

ecli find .|tail -1|awk '{print $3}'|xargs ecli slide info

Fixes #5