### PR TITLE
Windows distribution's binary should end with .exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.9 (2017-02-21)
 
 - Reading input config file with --config is ignored. #25
+- Windows distribution's binary should end with .exe. #24
 
 ## 0.8 (2017-02-19)
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ darwin:
 		(cd ${DISTDIR} && zip -r ${BIN_DARWIN_AMD64}.zip ${PROG})
 
 windows:
-	@cp bin/${BIN_VERSION}-windows* ${BINDIR}/${PROG} && \
+	@rm -f ${BINDIR}/${PROG}
+	@cp bin/${BIN_VERSION}-windows* ${BINDIR}/${PROG}.exe && \
 		(cd ${DISTDIR} && zip -r ${BIN_WINDOWS_AMD64}.zip ${PROG})
 
 freebsd:


### PR DESCRIPTION
Fixes #24