### PR TITLE
upload: fix memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.10
 
+- Fix memory leak during upload. #36
 - Do not require to be logged in to show ecli version. #32
 - Label create example shows wrong usage for description. #30
 


### PR DESCRIPTION
Memory profiling is now available to the upload command with the --memprofile flag.
Upload process allocates far less on the heap now.

Fixes #36